### PR TITLE
fix: update Gemini model ID and make it configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,22 @@ xattr -cr /Applications/WhisperFly.app
 
 This clears the `com.apple.quarantine` extended attribute recursively from the app bundle. Apple's Gatekeeper applies this flag to any app not signed with an Apple Developer certificate.
 
+### Reinstalling / Updating
+
+When you reinstall or update WhisperFly, macOS **does not** automatically trust the new binary for Accessibility. The old entry becomes stale and the app will silently fail to paste text.
+
+**You must remove and re-add WhisperFly in Accessibility settings:**
+
+1. **Quit** WhisperFly if it's running.
+2. Install the new version (Homebrew `brew upgrade whisperfly`, or drag the new `.app` to `/Applications`).
+3. Open **System Settings → Privacy & Security → Accessibility**.
+4. Find **WhisperFly** in the list — **select it and click the "−" (minus) button** to remove it entirely.
+5. Click **"+" (plus)**, navigate to `/Applications/WhisperFly.app`, and add it back.
+6. Make sure the toggle is **on**.
+7. Launch WhisperFly.
+
+> **Why?** macOS ties Accessibility permissions to the app's code signature / binary hash. After an update the old permission entry points to a binary that no longer matches, so the system revokes access silently. Toggling the switch off/on is **not enough** — you must fully remove and re-add the entry.
+
 ### Architecture
 
 ```
@@ -197,6 +213,22 @@ xattr -cr /Applications/WhisperFly.app
 ```
 
 Это рекурсивно удаляет атрибут `com.apple.quarantine` из пакета приложения. Gatekeeper Apple устанавливает этот флаг на любое приложение, не подписанное сертификатом Apple Developer.
+
+### Переустановка / Обновление
+
+При переустановке или обновлении WhisperFly macOS **не** доверяет новому бинарнику автоматически для Специальных возможностей (Accessibility). Старая запись становится недействительной, и приложение молча перестаёт вставлять текст.
+
+**Необходимо удалить и заново добавить WhisperFly в настройках Accessibility:**
+
+1. **Закройте** WhisperFly, если он запущен.
+2. Установите новую версию (Homebrew: `brew upgrade whisperfly`, или перетащите новый `.app` в `/Applications`).
+3. Откройте **Системные настройки → Конфиденциальность и безопасность → Специальные возможности** (Accessibility).
+4. Найдите **WhisperFly** в списке — **выделите его и нажмите кнопку «−» (минус)**, чтобы полностью удалить.
+5. Нажмите **«+» (плюс)**, перейдите к `/Applications/WhisperFly.app` и добавьте его заново.
+6. Убедитесь, что переключатель **включён**.
+7. Запустите WhisperFly.
+
+> **Почему?** macOS привязывает разрешения Accessibility к подписи / хешу бинарника приложения. После обновления старая запись ссылается на бинарник, который больше не совпадает, и система молча отзывает доступ. Переключение тумблера выкл/вкл **недостаточно** — нужно полностью удалить и заново добавить запись.
 
 ### Архитектура
 

--- a/Sources/WhisperFly/App/AppController.swift
+++ b/Sources/WhisperFly/App/AppController.swift
@@ -210,7 +210,7 @@ final class AppController: ObservableObject {
             if settings.geminiRewriteEnabled, !settings.openRouterApiKey.isEmpty {
                 status = .rewriting
                 do {
-                    let rewriter = GeminiRewriter(apiKey: settings.openRouterApiKey)
+                    let rewriter = GeminiRewriter(apiKey: settings.openRouterApiKey, model: settings.openRouterModel)
                     let rewriteResult = try await rewriter.rewrite(
                         inputText: result.text,
                         locale: Locale.current,
@@ -298,7 +298,7 @@ final class AppController: ObservableObject {
         case .groqWhisper:
             return GroqWhisperRecognizer(apiKey: settings.groqApiKey, language: settings.sourceLanguage)
         case .gemini:
-            return GeminiTranscriber(apiKey: settings.openRouterApiKey, language: settings.sourceLanguage)
+            return GeminiTranscriber(apiKey: settings.openRouterApiKey, language: settings.sourceLanguage, model: settings.openRouterModel)
         }
     }
     

--- a/Sources/WhisperFly/Models/AppSettings.swift
+++ b/Sources/WhisperFly/Models/AppSettings.swift
@@ -20,6 +20,7 @@ struct AppSettings: Codable, Sendable, Equatable {
     var pasteDelayMs: Int = 120
     var groqApiKey: String = ""
     var openRouterApiKey: String = ""
+    var openRouterModel: String = "google/gemini-2.5-flash"
     /// Supported source languages: en, ru, de, fr, es, ja, zh, ko, it, hi
     var sourceLanguage: String = "en"
     var targetLanguage: String = "en"

--- a/Sources/WhisperFly/Services/GeminiRewriter.swift
+++ b/Sources/WhisperFly/Services/GeminiRewriter.swift
@@ -3,10 +3,11 @@ import Foundation
 actor GeminiRewriter: TextRewriter {
     private let apiKey: String
     private let endpoint = URL(string: "https://openrouter.ai/api/v1/chat/completions")!
-    private let model = "google/gemini-2.5-flash-preview-05-20:free"
+    private let model: String
     
-    init(apiKey: String) {
+    init(apiKey: String, model: String = "google/gemini-2.5-flash") {
         self.apiKey = apiKey
+        self.model = model
     }
     
     func rewrite(inputText: String, locale: Locale, mode: RewriteMode) async throws -> RewriteResultPayload {

--- a/Sources/WhisperFly/Services/GeminiTranscriber.swift
+++ b/Sources/WhisperFly/Services/GeminiTranscriber.swift
@@ -4,11 +4,12 @@ actor GeminiTranscriber: SpeechRecognizer {
     private let apiKey: String
     private let language: String
     private let endpoint = URL(string: "https://openrouter.ai/api/v1/chat/completions")!
-    private let model = "google/gemini-2.5-flash-preview-05-20:free"
+    private let model: String
     
-    init(apiKey: String, language: String = "ru") {
+    init(apiKey: String, language: String = "ru", model: String = "google/gemini-2.5-flash") {
         self.apiKey = apiKey
         self.language = language
+        self.model = model
     }
     
     func transcribe(audioURL: URL) async throws -> TranscriptionResultPayload {

--- a/Sources/WhisperFly/Views/SettingsView.swift
+++ b/Sources/WhisperFly/Views/SettingsView.swift
@@ -108,6 +108,14 @@ struct SettingsView: View {
                 value: $controller.settings.pasteDelayMs,
                 in: 50...500, step: 25
             )
+            
+            Section(L("settings.openrouter_model_section", "OpenRouter Model")) {
+                TextField(L("settings.openrouter_model", "Model ID"), text: $controller.settings.openRouterModel)
+                    .textFieldStyle(.roundedBorder)
+                Text(L("settings.openrouter_model_hint", "Default: google/gemini-2.5-flash"))
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
         }
         .onChange(of: controller.settings) { _, _ in
             controller.saveSettings()


### PR DESCRIPTION
## Summary

Fixes #1 — the hardcoded OpenRouter model ID `google/gemini-2.5-flash-preview-05-20:free` was removed, causing a 400 error.

## Changes

- **Updated default model** to `google/gemini-2.5-flash` (current stable GA version on OpenRouter)
- **Made the model configurable** via `AppSettings.openRouterModel` so this won't break again when model IDs rotate
- **Passed model through** to `GeminiTranscriber` and `GeminiRewriter` init
- **Added Model ID field** in Settings → Advanced tab for power users

## Files changed

| File | Change |
|------|--------|
| `GeminiTranscriber.swift` | Model is now injected via init (default: `google/gemini-2.5-flash`) |
| `GeminiRewriter.swift` | Same — model injected via init |
| `AppSettings.swift` | Added `openRouterModel` property |
| `AppController.swift` | Passes `settings.openRouterModel` to both services |
| `SettingsView.swift` | Added Model ID text field in Advanced tab |